### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/CarSL/c6e2a571-a44c-439b-b23f-eb3505f45a56/bc05dcc0-5435-4795-aff8-1acaeb77b7f4/_apis/work/boardbadge/c77a63dc-0325-464e-ab3a-91725c133b67)](https://dev.azure.com/CarSL/c6e2a571-a44c-439b-b23f-eb3505f45a56/_boards/board/t/bc05dcc0-5435-4795-aff8-1acaeb77b7f4/Microsoft.RequirementCategory)
 # CarSl
 Become the king in your castle and sell your cars easy af
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#16](https://dev.azure.com/CarSL/c6e2a571-a44c-439b-b23f-eb3505f45a56/_workitems/edit/16). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.